### PR TITLE
Switch to secure RNG

### DIFF
--- a/bn256.py
+++ b/bn256.py
@@ -93,9 +93,9 @@ def rand_elem():
     """ Debiased random element generator """
     while True:
         rand_bytes = os.urandom(rand_elem_bytes)
-        rand_num = int.from_bytes(rand_bytes, 'little')
+        rand_num = int.from_bytes(rand_bytes, sys.byteorder)
         res = rand_num % rand_elem_range
-        if (rand_num - res) < rand_elem_barrier:
+        if (rand_num - res) <= rand_elem_barrier:
             return res + rand_elem_base
 
 # Montgomery params

--- a/bn256.py
+++ b/bn256.py
@@ -28,8 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import hashlib
-import random
 import sys
+import os
 
 v = 1868033
 #v = 0b111001000000100000001
@@ -82,6 +82,21 @@ def legendre(a):
     if x == p-1:
         return -1
     assert False
+
+# Takes larger random range to minimize ratio of unusable numbers
+rand_elem_bytes = (order.bit_length() + 7) // 8 + 1
+rand_elem_base = 2
+rand_elem_range = order - rand_elem_base
+rand_elem_barrier = (1 << (8 * rand_elem_bytes)) - rand_elem_range
+
+def rand_elem():
+    """ Debiased random element generator """
+    while True:
+        rand_bytes = os.urandom(rand_elem_bytes)
+        rand_num = int.from_bytes(rand_bytes, 'little')
+        res = rand_num % rand_elem_range
+        if (rand_num - res) < rand_elem_barrier:
+            return res + rand_elem_base
 
 # Montgomery params
 R = pow(2,256)
@@ -1057,7 +1072,7 @@ def g1_scalar_base_mult(k):
     return curve_G.scalar_mul(k)
 
 def g1_random():
-    k = random.randrange(2, order)
+    k = rand_elem()
     return k, g1_scalar_base_mult(k)
 
 def g1_add(a, b):
@@ -1150,7 +1165,7 @@ def g2_scalar_base_mult(k):
     return twist_G.scalar_mul(k)
 
 def g2_random():
-    k = random.randrange(2, order)
+    k = rand_elem()
     return k, g2_scalar_base_mult(k)
 
 def g2_add(a, b):


### PR DESCRIPTION
This PR switches generation of random group elements to secure system random number generator.

Previous implementation used `random.randrange` routine to obtain random integer from given range. Documentation for Python `random` module states:

> The pseudo-random generators of this module should not be used for security purposes.

Indeed, `random` module is a PRNG which by default is initialized with current time, or initialized globally by other code with possibly not-so-random value.

Python 3.6+ has a `secrets` module which fits well, but Python 3.6 is not widely available itself. For portability reasons I implemented unbiased random element generator based on system secure random number generator `os.urandom`. It should work on most platforms, including Windows (Python uses `CryptGenRandom()` in later case).