### PR TITLE
fix handling of neutral element in point_scalar_mul and point_force_a…

### DIFF
--- a/bn256.py
+++ b/bn256.py
@@ -304,6 +304,9 @@ def point_force_affine(point):
     if point.z.is_one():
         return
 
+    if point.z.is_zero():
+        return
+
     zinv = point.z.inverse()
     zinv2 = (zinv * zinv)
     zinv3 = (zinv2 * zinv)
@@ -314,6 +317,9 @@ def point_force_affine(point):
 
 def point_scalar_mul(pt, k):
     assert is_integer_type(k)
+
+    if int(k) == 0:
+        return pt.__class__(pt.one_element(), pt.one_element(), pt.zero_element())
 
     R = [pt.__class__(pt.zero_element(), pt.zero_element(), pt.zero_element()),
          pt]


### PR DESCRIPTION
If I am not mistaken, the case "scaling by 0" in bn256.point_scalar_mul() should be included and return the neutral element. I have adapted point_scalar_mul() to return the neutral element in this case.

Also, I added a case to handle the neutral element in bn256.point_force_affine(). 

Btw, your bn256 module is great. I used it to implement the Pinocchio ZK-SNARK in pure Python. Thanks for the great work! 