### PR TITLE
Fix marshall of elements in G2

### DIFF
--- a/bn256.py
+++ b/bn256.py
@@ -1172,6 +1172,7 @@ def g2_add(a, b):
     return a.add(b)
 
 def g2_marshall(a):
+    a.force_affine()
     return (a.x.x, a.x.y, a.y.x, a.y.y)
 
 def g2_unmarshall(w,x,y,z):


### PR DESCRIPTION
For marshaling purposes, G2 elements, i.e. points in the twist of the curve over GF(p^2), are represented in affine form.

Hit this case while prototyping the Boneh-Franklin IBE, for which I may open a PR in the future.

Great library @randombit.